### PR TITLE
Update CONTRIBUTING.md:  Python <3.12 requirement for TensorFlow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,7 @@ development purposes but also feel free to just use the containers and update wi
 
 
 ### Local Set Up
-It is recommended to use Python versions >= 3.11.
+It is recommended to use Python versions >= 3.11 < 3.12.
 
 This guide skips setting up User Authentication for the purpose of simplicity
 


### PR DESCRIPTION
During the onboarding process, it was discovered that TensorFlow does not yet support Python 3.12. The README has been updated to reflect that the project must remain on Python versions below 3.12 to maintain TensorFlow compatibility.